### PR TITLE
fix(ci): restore container releases broken by bake-action v7

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -135,9 +135,8 @@ jobs:
             ${{ inputs.release && format('*.output=type=image,name=ghcr.io/{0}/{1},push-by-digest=true,name-canonical=true,push=true', github.repository_owner, inputs.app) || '*.output=type=docker' }}
             *.platform=${{ matrix.platform }}
             *.tags=
-          source: .
+          source: ./apps/${{ inputs.app }}
           targets: image
-          workdir: ./apps/${{ inputs.app }}
 
       - if: ${{ ! inputs.release }}
         name: Run Application Tests

--- a/.github/workflows/retry-release.yaml
+++ b/.github/workflows/retry-release.yaml
@@ -72,15 +72,6 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
 
       - if: ${{ steps.app-options.outputs.version != steps.registry.outputs.version }}
-        name: Find Pull Request
-        uses: juliangruber/find-pull-request-action@33d46d4ff90884bb23aaead16044125daaf733d8 # v1.11.0
-        id: find-pull-request
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          labels: app/${{ matrix.app }}
-          state: open
-
-      - if: ${{ steps.find-pull-request.outputs.number != '' }}
         name: Retry Release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

No container images have published since **2026-05-10**. Renovate keeps opening and auto-merging version-bump PRs (so `docker-bake.hcl` files advance — e.g. home-assistant is at `2026.6.3` in git), but every `Release` workflow run since **2026-05-12** fails at the `Build Application` step. The daily `Retry Release` safety-net also fails to recover them.

## Root cause

PR #166 bumped `docker/bake-action` **v6.10.0 → v7.1.0** (a breaking major). The v7 line removed the `workdir` input — [release notes](https://github.com/docker/bake-action/releases/tag/v7.0.0): *"The `workdir` input is now merged into `source`"*. But `app-builder.yaml` still passed `workdir`, so it was silently ignored and `docker buildx bake` ran from the **repo root** instead of `apps/<app>/`:

```
##[warning]Unexpected input(s) 'workdir', valid inputs are ['builder','allow','call','files',...]
#1 [internal] load local bake definitions
ERROR: open ./docker-bake.hcl: no such file or directory
##[error]cannot parse bake definitions
```

Confirmed identical on the first failure (k8s-sidecar, 2026-05-12) and the latest (home-assistant, 2026-06-14). The last *successful* run (2026-05-10) used v6.10.0 where `workdir` still worked.

## Fixes

### 1. `app-builder.yaml` — use `source` (v7 replacement for `workdir`)

```diff
-          source: .
+          source: ./apps/${{ inputs.app }}
           targets: image
-          workdir: ./apps/${{ inputs.app }}
```

Per the [bake-action source semantics](https://github.com/docker/bake-action?tab=readme-ov-file#source-semantics): *"When `source` is a local path, the action runs Bake from that directory (equivalent to `cd <path> && docker buildx bake`)"*. Relative paths in `files` (e.g. `./docker-bake.hcl`) now resolve from the app dir, matching the v6 behavior.

### 2. `retry-release.yaml` — actually retry stale images

The daily retry only re-triggered `release.yaml` when an **OPEN** PR labeled `app/<app>` existed. Because Renovate auto-merges those PRs (`.renovaterc.json5` `automerge: true`), they're never open when retry-release runs → `find-pull-request` returns nothing → the `gh workflow run release.yaml` step is always skipped. The workflow shows green but never recovers anything.

Drop the `find-pull-request` gate and retry purely on registry-vs-repo version mismatch:

```diff
-      - if: ${{ steps.app-options.outputs.version != steps.registry.outputs.version }}
-        name: Find Pull Request
-        uses: juliangruber/find-pull-request-action@...   # removed
-        ...
-      - if: ${{ steps.find-pull-request.outputs.number != '' }}
+      - if: ${{ steps.app-options.outputs.version != steps.registry.outputs.version }}
         name: Retry Release
```

Once fix #1 lands, this will rebuild all stale images. After a successful rebuild, the `:rolling` tag's `org.opencontainers.image.version` label updates and the mismatch clears — no infinite loop.

## Verification
- Both workflow files pass YAML parse validation.
- Confirmed `source` is the documented v7 replacement for `workdir` (bake-action README + v7.0.0 release notes).
- Confirmed no other `workdir` usages remain in the repo.
- After merge: the next `Retry Release` run (01:30 UTC daily) should rebuild home-assistant, plex, qbittorrent, k8s-sidecar, postgres-init, and mysql-init to their current git versions.