### PR TITLE
fix(ci): allow retry-release to dispatch workflows (actions:write)

### DIFF
--- a/.github/workflows/retry-release.yaml
+++ b/.github/workflows/retry-release.yaml
@@ -7,6 +7,10 @@ on:
     - cron: "30 1 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   apps:
     name: Get App Inventory
@@ -74,7 +78,7 @@ jobs:
       - if: ${{ steps.app-options.outputs.version != steps.registry.outputs.version }}
         name: Retry Release
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh workflow run release.yaml \
               --repo ${{ github.repository }} \


### PR DESCRIPTION
## Problem

Follow-up to #210. After the open-PR gate was removed, retry-release now correctly fires the `Retry Release` step for stale apps — but the dispatch fails:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
(https://api.github.com/repos/lenaxia/containers/actions/workflows/162523848/dispatches)
```

The bot app token (`BOT_APP_ID`) used to run `gh workflow run` lacks the **Actions:Write** permission required to create `workflow_dispatch` events. That permission is a GitHub App setting (configured in the App/repo settings), which cannot be granted from a workflow file.

## Fix

Grant the workflow `actions: write` and dispatch `release.yaml` using the run's own `GITHUB_TOKEN` (`github.token`) instead of the app token. `github.token` can dispatch workflows within the same repo when explicitly granted `actions: write` permission.

```diff
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   ...
       - name: Retry Release
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
```

The app token is still generated and used for the `regctl image inspect` registry-version read (unchanged).

## Context — full release-pipeline repair
1. #210 — `app-builder.yaml`: bake-action v7 removed `workdir` → use `source: ./apps/<app>` (**verified**: `Build Application` step now succeeds).
2. #210 — `retry-release.yaml`: drop open-PR gate so stale apps are retried.
3. **This PR** — grant `actions: write` so the retry can actually dispatch.

After this merges, the nightly `Retry Release` (01:30 UTC) will rebuild all stale images (home-assistant, plex, qbittorrent, k8s-sidecar, mysql-init, postgres-init) without intervention.