### PR TITLE
feat: add opencode.json for AI workflows

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
+  "provider": {
+    "openai-compatible": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Custom OpenAI-compatible endpoint",
+      "options": {
+        "baseURL": "{env:OPENAI_API_BASE}",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "default": {
+          "name": "{env:OPENAI_MODEL}",
+          "id": "{env:OPENAI_MODEL}"
+        }
+      }
+    }
+  },
+  "permission": {
+    "*": "allow",
+    "bash": {
+      "*": "deny",
+      "git*": "allow",
+      "gh*": "allow",
+      "mkdir*": "allow",
+      "cat*": "allow",
+      "ls*": "allow",
+      "pwd": "allow",
+      "jq*": "allow",
+      "docker*": "allow",
+      "task*": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `opencode.json` at repo root for OpenCode CLI used by ai-workflows.

- OpenAI-compatible provider config via `OPENAI_API_BASE` / `OPENAI_API_KEY` / `OPENAI_MODEL` env vars
- Deny-by-default bash policy with `docker` and `task` allowed (container build repo)