### PR TITLE
fix: include renovate PRs in automated review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   review:
-    if: github.event.pull_request.user.login != 'renovate[bot]'
     uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@374b026a6ff2e471f5aad733b58acb68c81e4b53 # v0.2.0
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Removes the `renovate[bot]` exclusion from `pr-review.yml` so dependency-update PRs receive automated code review. This unblocks auto-merge for Renovate PRs like #247.

The original exclusion was added during onboarding to avoid reviewing bots, but Renovate PRs are low-risk pin bumps that still benefit from validation.