### PR TITLE
chore(ai): sync to ai-workflows@v0.2.9

### DIFF
--- a/.github/workflows/ai-comment.yml
+++ b/.github/workflows/ai-comment.yml
@@ -42,8 +42,8 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR')
-    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@374b026a6ff2e471f5aad733b58acb68c81e4b53 # v0.2.0
+    uses: lenaxia/ai-workflows/.github/workflows/ai-comment.yml@v0.2.9 # v0.2.0
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: containers

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   respond:
-    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@374b026a6ff2e471f5aad733b58acb68c81e4b53 # v0.2.0
+    uses: lenaxia/ai-workflows/.github/workflows/issue-opened.yml@v0.2.9 # v0.2.0
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: containers

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   review:
-    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@374b026a6ff2e471f5aad733b58acb68c81e4b53 # v0.2.0
+    uses: lenaxia/ai-workflows/.github/workflows/pr-review.yml@v0.2.9 # v0.2.0
     secrets: inherit
     with:
-      version: v0.2.0
+      version: v0.2.9
       project_name: containers


### PR DESCRIPTION
Manual sync from lenaxia/ai-workflows@v0.2.9.

propagate.yml computed this bump but could not open a cross-repo PR (AI_WORKFLOWS_PAT not set). PR opened manually.

## What's in v0.2.9

- **PR #30** — Skip automation-bots (renovate, github-actions, release-please, dependabot, mergify, github-merge-queue) in the reusable pr-review.yml. Bot PRs now skip cleanly instead of failing with `permission: none`.
- Reverts PR #28 (dead TOKEN env workaround). Verified the opencode CLI's assertPermissions doesn't honor the legacy skip path.

## Diff

Bumps the three caller workflow files (`issue-opened.yml`, `pr-review.yml`, `ai-comment.yml`) from their current pin to `@v0.2.9`. No source/prompt changes (those are forked/consumer-owned).