### PR TITLE
ci(renovate): exclude lenaxia/ai-workflows pins from Renovate (propagate-only)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -57,6 +57,18 @@
   packageRules: [
     {
       description: [
+        'ai-workflows pins are bumped by propagate.yml syncs only',
+      ],
+      matchManagers: [
+        'github-actions',
+      ],
+      matchPackageNames: [
+        'lenaxia/ai-workflows',
+      ],
+      enabled: false,
+    },
+    {
+      description: [
         'Release Rules for Application Updates',
       ],
       addLabels: [


### PR DESCRIPTION
## What

One new first `packageRule` in `.renovaterc.json5`: disable Renovate entirely for `lenaxia/ai-workflows` (`enabled: false`, exact `matchPackageNames`).

## Why

The existing `Auto-merge GitHub Actions dependencies` rule (`automergeType: 'pr'`, auto-merged once checks pass) manages the sibling callers' SHA-pinned `uses: lenaxia/ai-workflows/...@5f900a24…# v0.2.10` refs. A tag bump PR rewrites the SHA/comment **only** — Renovate never updates `with:` inputs (only its built-in community `uses-with` table gets that) — so the sibling callers' `version: v0.2.10` input (the checkout ref for scripts/prompts) would be stranded, and propagate.yml's `s|version: OLD_TAG|version: NEW_TAG|g` repair sed can never match again (it derives `OLD_TAG` from the already-bumped `uses:` line).

Not theoretical: **talos-ops-prod main got stranded exactly this way today** (`22e5abac` bumped the pin via automerge, `version:` stayed stale — fixed in talos-ops-prod#2286).

`enabled: false` rather than `automerge: false`: even a human-merged Renovate PR for these pins would bump `uses:` without `version:` and re-strand. Pins move via propagate.yml lockstep syncs only. Org-wide tracking: ai-workflows#39.

## Verification

- `.renovaterc.json5` parses via JSON5 validator (11 packageRules).
- No other changes.