### PR TITLE
feat(xianscan): add app

### DIFF
--- a/apps/xianscan/Dockerfile
+++ b/apps/xianscan/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+#
+# xianscan — local-first comic/manga translation studio (Rust + ONNX Runtime).
+# Upstream ships a self-contained linux-amd64 binary with the ONNX models,
+# SvelteKit web UI, and Node.js runtime embedded; it runs CPU-first and
+# activates CUDA only when cuDNN 9 libraries are importable at runtime.
+#
+# The release tarball also carries libonnxruntime_providers_*.so (CUDA/TensorRT
+# execution providers). They are inert without cuDNN and an NVIDIA device, so
+# the same image serves CPU and GPU hosts (NVIDIA Container Toolkit required
+# for the latter, plus cuDNN 9 on LD_LIBRARY_PATH).
+
+FROM docker.io/library/ubuntu:24.04
+ARG VERSION
+
+ENV XDG_DATA_HOME=/config \
+    XDG_CACHE_HOME=/config/.cache \
+    HOME=/config
+
+USER root
+WORKDIR /app
+
+RUN \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        fontconfig \
+        fonts-dejavu-core \
+        wget \
+    && wget -q "https://github.com/ArbenApura/xianscan-rust/releases/download/v${VERSION}/xianscan-linux-x86_64.tar.gz" -O /tmp/xianscan.tar.gz \
+    && tar -xzf /tmp/xianscan.tar.gz -C /app \
+    && rm -rf /tmp/xianscan.tar.gz \
+    && chmod +x /app/xianscan \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 568 app \
+    && useradd -u 568 -g 568 -d /config -M -s /usr/sbin/nologin app \
+    && mkdir -p /config \
+    && chown -R app:app /config /app
+
+USER app:app
+
+VOLUME ["/config"]
+
+EXPOSE 8124
+
+ENTRYPOINT ["/app/xianscan"]

--- a/apps/xianscan/Dockerfile
+++ b/apps/xianscan/Dockerfile
@@ -13,7 +13,8 @@
 FROM docker.io/library/ubuntu:24.04
 ARG VERSION
 
-ENV XDG_DATA_HOME=/config \
+ENV DEBIAN_FRONTEND=noninteractive \
+    XDG_DATA_HOME=/config \
     XDG_CACHE_HOME=/config/.cache \
     HOME=/config
 
@@ -37,7 +38,9 @@ RUN \
     && groupadd -g 568 app \
     && useradd -u 568 -g 568 -d /config -M -s /usr/sbin/nologin app \
     && mkdir -p /config \
-    && chown -R app:app /config /app
+    && chown -R app:app /config \
+    && chown -R root:root /app \
+    && chmod -R 755 /app
 
 USER app:app
 

--- a/apps/xianscan/README.md
+++ b/apps/xianscan/README.md
@@ -1,0 +1,44 @@
+# xianscan
+
+[xianscan-rust](https://github.com/ArbenApura/xianscan-rust) packaged from the
+upstream self-contained release binary — a local-first translation studio for
+manga, manhwa, and manhua (speech-bubble detection, multi-language OCR, LLM
+translation, LaMa inpainting, typesetting) served as a web UI.
+
+## Usage
+
+```yaml
+services:
+  xianscan:
+    image: ghcr.io/lenaxia/containers/xianscan:0.5.0-beta.2
+    ports:
+      - "8124:8124"
+    volumes:
+      - ./xianscan-config:/config
+```
+
+Open `http://localhost:8124`. The first launch extracts the embedded web assets
+into `/config` and loads the ONNX models into memory; expect a slow start
+(~30s).
+
+## Storage
+
+Everything persistent lives under `/config` (`XDG_DATA_HOME`):
+
+| Path | Contents |
+| :--- | :--- |
+| `/config/xianscan/app` | Extracted SvelteKit web UI + Node runtime (first run) |
+| `/config/xianscan/data` | SQLite library, book/chapter image caches, covers |
+
+## Notes
+
+- **amd64 only** — upstream publishes linux-x86_64 binaries only.
+- **CPU-first**: runs multi-threaded CPU inference out of the box. The binary
+  carries the ONNX Runtime CUDA execution providers; to enable GPU inference,
+  run with the NVIDIA Container Toolkit and provide cuDNN 9 on
+  `LD_LIBRARY_PATH` (otherwise it silently falls back to CPU).
+- **Translation LLM is external** — point the in-app settings at Ollama, LM
+  Studio, or a cloud API. From another container use
+  `http://ollama:11434`-style service addresses.
+- The internal ML engine listens on loopback `:8123` inside the container; only
+  `:8124` needs publishing.

--- a/apps/xianscan/docker-bake.hcl
+++ b/apps/xianscan/docker-bake.hcl
@@ -1,0 +1,34 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=ArbenApura/xianscan-rust
+  default = "0.5.0-beta.2"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/ArbenApura/xianscan-rust"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = ["linux/amd64"]
+}

--- a/apps/xianscan/tests.yaml
+++ b/apps/xianscan/tests.yaml
@@ -3,6 +3,13 @@
 process:
   xianscan:
     running: true
+file:
+  /app/xianscan:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0755"
 port:
   tcp:8124:
     listening: true

--- a/apps/xianscan/tests.yaml
+++ b/apps/xianscan/tests.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+process:
+  xianscan:
+    running: true
+port:
+  tcp:8124:
+    listening: true
+http:
+  http://localhost:8124:
+    status: 200
+    timeout: 30000
+  http://localhost:8123/health:
+    status: 200
+    timeout: 30000


### PR DESCRIPTION
## What

Adds [xianscan-rust](https://github.com/ArbenApura/xianscan-rust) — local-first comic/manga/manhwa translation studio (RF-DETR bubble detection, RapidOCR, LaMa inpainting, LLM translation, typesetting) served as a web UI on `:8124`.

Packages the upstream self-contained release binary (all ONNX models, SvelteKit web UI, and Node runtime embedded via `--features embed-models,embed-web` — **no downloads at runtime**). Follows the nzbhydra2 release-download pattern.

## Files

- `Dockerfile` — ubuntu:24.04 base, release tarball fetched at build time, rootless `568:568`, `XDG_DATA_HOME=/config` for persistence
- `docker-bake.hcl` — `VERSION` pinned to `0.5.0-beta.2`, renovate `github-releases` datasource, `linux/amd64` only (upstream ships no arm64 Linux binary)
- `tests.yaml` — goss: process, `tcp:8124`, HTTP 200 on `/` and `:8123/health`
- `README.md` — usage, storage layout, GPU notes

## Verification

Smoke-tested the actual release binary outside Docker:

- Tarball layout: root-level `xianscan` (618M) + `libonnxruntime_providers_*.so` (inert without cuDNN; CPU fallback)
- Requires glibc >= 2.39 + `GLIBCXX_3.4.31` → ubuntu:24.04 is the minimum base (fails on Debian 12 / Ubuntu 22.04)
- Full boot with `XDG_DATA_HOME` redirected: embedded Node extracted to `<xdg>/xianscan/app/bin/node`, `GET /` on :8124 → 200, `GET :8123/health` → `status:ok`, `CPUExecutionProvider`, v0.5.0-beta.2

## Caveats

- First boot loads ~411MB of embedded ONNX models into memory (~30-60s on a 4-core runner) — may brush against the fixed 60s goss `--retry-timeout` in `app-tests`; bump there if flaky
- CUDA: ships provider libs but needs NVIDIA Container Toolkit + cuDNN 9 on `LD_LIBRARY_PATH`, else silent CPU fallback (documented in app README)
- Translation LLM is external (Ollama / LM Studio / cloud APIs) by design